### PR TITLE
Introduce type-specific host fields for MysqlConfig and PostgresqlConfig

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "task"
-version = "2.11.1"
+version = "2.12.0"
 authors = ["Ballerina"]
 keywords = ["task", "job", "schedule"]
 repository = "https://github.com/ballerina-platform/module-ballerina-task"
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "task-native"
-version = "2.11.1"
-path = "../native/build/libs/task-native-2.11.1.jar"
+version = "2.12.0"
+path = "../native/build/libs/task-native-2.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId="org.quartz-scheduler"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.0"
+version = "2.9.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -82,7 +82,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.1"
+version = "2.12.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.runtime"},

--- a/ballerina/commons.bal
+++ b/ballerina/commons.bal
@@ -24,35 +24,41 @@ public type Service distinct service object {
 # Represents the configuration required to connect to a database related to task coordination.
 public type DatabaseConfig MysqlConfig|PostgresqlConfig;
 
-# Represents the configuration required to connect to a database related to task coordination.
+# Represents the configuration required to connect to a MySQL database related to task coordination.
 #
-# + host - The hostname of the database server
+# + mysqlHost - The hostname of the MySQL server
+# + host - The hostname of the MySQL server (deprecated, use `mysqlHost`)
 # + user - The username for the database connection
 # + password - The password for the database connection
 # + port - The port number of the database server
 # + database - The name of the database to connect to
-public type MysqlConfig record {
-  string host = "localhost";
+public type MysqlConfig record {|
+  string mysqlHost = "localhost";
+  @deprecated
+  string host?;
   string? user = ();
   string? password = ();
   int port = 3306;
   string? database = ();
-};
+|};
 
-# Represents the configuration required to connect to a database related to task coordination.
+# Represents the configuration required to connect to a PostgreSQL database related to task coordination.
 #
-# + host - The hostname of the database server
+# + postgresqlHost - The hostname of the PostgreSQL server
+# + host - The hostname of the PostgreSQL server (deprecated, use `postgresqlHost`)
 # + user - The username for the database connection
 # + password - The password for the database connection
 # + port - The port number of the database server
 # + database - The name of the database to connect to
-public type PostgresqlConfig record {
-  string host = "localhost";
+public type PostgresqlConfig record {|
+  string postgresqlHost = "localhost";
+  @deprecated
+  string host?;
   string? user = ();
   string? password = ();
   int port = 5432;
   string? database = ();
-};
+|};
 
 # Represents the configuration required for task coordination.
 #
@@ -63,7 +69,9 @@ public type PostgresqlConfig record {
 #             coordinating the task. It is recommended to use a unique identifier for each group of tasks.
 # + heartbeatFrequency - The interval (in seconds) for the node to update its heartbeat. Default is one second.
 public type WarmBackupConfig record {
-    DatabaseConfig databaseConfig = <MysqlConfig>{};
+    DatabaseConfig databaseConfig = {
+        mysqlHost: "localhost"
+    };
     int livenessCheckInterval = 30;
     string taskId;
     string groupId;

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- [Introduce type-specific host fields (`mysqlHost`, `postgresqlHost`) for `MysqlConfig` and `PostgresqlConfig`, deprecating the generic `host` field to resolve ambiguous type issues](https://github.com/ballerina-platform/ballerina-library/issues/8694)
+
 - [Add retry support for listeners](https://github.com/wso2-enterprise/internal-support-ballerina/issues/1043)
 
 ## [2.10.0]

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -206,7 +206,9 @@ The warm backup configuration enables high availability for distributed task exe
 #             coordinating the task. It is recommended to use a unique identifier for each group of tasks.
 # + heartbeatFrequency - The interval (in seconds) for the node to update its heartbeat. Default is one second.
 public type WarmBackupConfig record {
-  DatabaseConfig databaseConfig = <MysqlConfig>{};
+  DatabaseConfig databaseConfig = {
+      mysqlHost: "localhost"
+  };
   int livenessCheckInterval = 30;
   string taskId;
   string groupId;
@@ -339,39 +341,45 @@ The `databaseConfig` can be either MySQL or PostgreSQL. This is defined using a 
 **For PostgreSQL:**
 
 ```ballerina
-# Represents the configuration required to connect to a database related to task coordination.
+# Represents the configuration required to connect to a PostgreSQL database related to task coordination.
 #
-# + host - The hostname of the database server
+# + postgresqlHost - The hostname of the PostgreSQL server
+# + host - The hostname of the PostgreSQL server (deprecated, use `postgresqlHost`)
 # + user - The username for the database connection
 # + password - The password for the database connection
 # + port - The port number of the database server
 # + database - The name of the database to connect to
-public type PostgresqlConfig record {
-  string host = "localhost";
+public type PostgresqlConfig record {|
+  string postgresqlHost = "localhost";
+  @deprecated
+  string host?;
   string? user = ();
   string? password = ();
   int port = 5432;
   string? database = ();
-};
+|};
 ```
 
 **For MySQL:**
 
 ```ballerina
-# Represents the configuration required to connect to a database related to task coordination.
+# Represents the configuration required to connect to a MySQL database related to task coordination.
 #
-# + host - The hostname of the database server
+# + mysqlHost - The hostname of the MySQL server
+# + host - The hostname of the MySQL server (deprecated, use `mysqlHost`)
 # + user - The username for the database connection
 # + password - The password for the database connection
 # + port - The port number of the database server
 # + database - The name of the database to connect to
-public type MysqlConfig record {
-  string host = "localhost";
+public type MysqlConfig record {|
+  string mysqlHost = "localhost";
+  @deprecated
+  string host?;
   string? user = ();
   string? password = ();
   int port = 3306;
   string? database = ();
-};
+|};
 ```
 
 ## 8.2. Task Coordination Example

--- a/examples/task-coordination/README.md
+++ b/examples/task-coordination/README.md
@@ -48,25 +48,25 @@ The `databaseConfig` can be either MySQL or PostgreSQL. This is defined using a 
 **For PostgreSQL:**
 
 ```ballerina
-type PostgresqlConfig record {
-   string host;
+type PostgresqlConfig record {|
+   string postgresqlHost;
    int port;
    string user;
    string password;
    string database;
-};
+|};
 ```
 
 **For MySQL:**
 
 ```ballerina
-type MysqlConfig record {
-   string host;
+type MysqlConfig record {|
+   string mysqlHost;
    int port;
    string user;
    string password;
    string database;
-};
+|};
 ```
 
 ### Setting Up task coordination

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=2.11.2-SNAPSHOT
+version=2.12.0-SNAPSHOT
 
 ballerinaLangVersion=2201.12.0
 axiomVersion=1.2.22

--- a/native/src/main/java/io/ballerina/stdlib/task/coordination/TokenAcquisition.java
+++ b/native/src/main/java/io/ballerina/stdlib/task/coordination/TokenAcquisition.java
@@ -40,6 +40,9 @@ import static io.ballerina.stdlib.task.server.TaskServerJob.handleRollback;
  */
 public final class TokenAcquisition {
     public static final BString DB_HOST = StringUtils.fromString("host");
+    public static final BString DB_MYSQL_HOST = StringUtils.fromString("mysqlHost");
+    public static final BString DB_POSTGRESQL_HOST = StringUtils.fromString("postgresqlHost");
+    public static final String DEFAULT_HOST = "localhost";
     public static final BString DB_USER = StringUtils.fromString("user");
     public static final BString DB_PASSWORD = StringUtils.fromString("password");
     public static final BString DB_PORT = StringUtils.fromString("port");
@@ -80,6 +83,26 @@ public final class TokenAcquisition {
     private TokenAcquisition() { }
 
     /**
+     * Resolves the host from the database config record.
+     * Checks the type-specific host field (mysqlHost/postgresqlHost) first.
+     * If it is set to a non-default value, that is used. Otherwise falls back to the deprecated
+     * {@code host} field if present, and finally defaults to "localhost".
+     */
+    private static String resolveHost(BMap<Object, Object> databaseConfig, String dbType) {
+        BString specificHostKey = DB_TYPE_MYSQL.equals(dbType) ? DB_MYSQL_HOST : DB_POSTGRESQL_HOST;
+        if (databaseConfig.containsKey(specificHostKey)) {
+            String specificHost = databaseConfig.getStringValue(specificHostKey).getValue();
+            if (!DEFAULT_HOST.equals(specificHost)) {
+                return specificHost;
+            }
+        }
+        if (databaseConfig.containsKey(DB_HOST)) {
+            return databaseConfig.getStringValue(DB_HOST).getValue();
+        }
+        return DEFAULT_HOST;
+    }
+
+    /**
      * Acquires token with proper transaction handling.
      */
     public static Object acquireToken(BMap<Object, Object> databaseConfig,
@@ -91,7 +114,7 @@ public final class TokenAcquisition {
             dbType = databaseConfig.getStringValue(DB_TYPE).getValue().toLowerCase();
         }
         DatabaseConfig dbConfig = new DatabaseConfig(
-                databaseConfig.getStringValue(DB_HOST).getValue(), databaseConfig.getStringValue(DB_USER).getValue(),
+                resolveHost(databaseConfig, dbType), databaseConfig.getStringValue(DB_USER).getValue(),
                 databaseConfig.getStringValue(DB_PASSWORD).getValue(), databaseConfig.getIntValue(DB_PORT).intValue(),
                 databaseConfig.getStringValue(DATABASE).getValue(), dbType
         );


### PR DESCRIPTION
## Summary

- Add `mysqlHost` to `MysqlConfig` and `postgresqlHost` to `PostgresqlConfig`, deprecating the generic `host` field in both records
- Makes the two records structurally distinct, resolving the **ambiguous type error** in the `DatabaseConfig = MysqlConfig|PostgresqlConfig` union
- Native `resolveHost` logic: prefers the type-specific field if set to a non-default value, falls back to deprecated `host` if present, defaults to `"localhost"`
- `WarmBackupConfig` default updated from `<MysqlConfig>{}` to `{mysqlHost: "localhost"}` (no type cast needed)
- Changelog and spec updated

## Backward Compatibility

Non-breaking (minor version bump). The deprecated `host` field is retained as `string host?` in both records — existing code continues to compile with a deprecation warning.

## Test Plan

- [x] Existing `invalidConfigListener` (MySQL + deprecated `host:`) — backward compat
- [x] `invalidConfigListenerNewFields` (MySQL + new `mysqlHost:`)
- [x] `invalidConfigListenerPostgresDeprecated` (PostgreSQL + deprecated `host:`)
- [x] `invalidConfigListenerPostgresNewFields` (PostgreSQL + new `postgresqlHost:`)

Closes https://github.com/ballerina-platform/ballerina-library/issues/8694

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Type-Specific Host Fields for Database Configurations

## Overview
Introduces type-specific host fields for database configurations to resolve a type ambiguity issue in the union of `MysqlConfig` and `PostgresqlConfig`. The changes maintain full backward compatibility through field deprecation.

## Core Changes
- **New Fields**: Adds `mysqlHost` to `MysqlConfig` and `postgresqlHost` to `PostgresqlConfig`, each with a default value of `"localhost"`
- **Backward Compatibility**: Retains the generic `host` field in both records, marked as deprecated and optional
- **Host Resolution Logic**: Implements native resolution that prioritizes type-specific fields, falls back to the deprecated `host` field if set, and defaults to `"localhost"`
- **Configuration Updates**: Changes `WarmBackupConfig`'s default database configuration from a cast-based instantiation to an inline object using the new `mysqlHost` field

## Implementation Details
- Updates record definitions with closed object syntax (`{| ... |}`)
- Adds constants and helper methods in the Java implementation layer to handle host field resolution
- Removes type casting requirements in default configurations
- Updates specification and documentation to reflect the new field names

## Version & Compatibility
- Minor version bump from 2.11.x to 2.12.0
- Non-breaking change: existing code continues to compile with deprecation warnings on the `host` field
- Resolves ambiguous-type error for the `DatabaseConfig` union while preserving structural compatibility

## Documentation
- Updates changelog with deprecation notice
- Updates specification and examples to reference new field names
- Includes deprecation annotations on the original `host` field
<!-- end of auto-generated comment: release notes by coderabbit.ai -->