### PR TITLE
Introduce dbType discriminator field to resolve DatabaseConfig ambiguous type

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "task"
-version = "2.11.1"
+version = "2.12.0"
 authors = ["Ballerina"]
 keywords = ["task", "job", "schedule"]
 repository = "https://github.com/ballerina-platform/module-ballerina-task"
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "task-native"
-version = "2.11.1"
-path = "../native/build/libs/task-native-2.11.1.jar"
+version = "2.12.0"
+path = "../native/build/libs/task-native-2.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId="org.quartz-scheduler"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.0"
+version = "2.9.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -82,7 +82,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.1"
+version = "2.12.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.runtime"},

--- a/ballerina/commons.bal
+++ b/ballerina/commons.bal
@@ -24,35 +24,45 @@ public type Service distinct service object {
 # Represents the configuration required to connect to a database related to task coordination.
 public type DatabaseConfig MysqlConfig|PostgresqlConfig;
 
-# Represents the configuration required to connect to a database related to task coordination.
+# Identifies a MySQL database type.
+public type Mysql "mysql";
+
+# Identifies a PostgreSQL database type.
+public type Postgresql "postgresql";
+
+# Represents the configuration required to connect to a MySQL database related to task coordination.
 #
+# + dbType - The database type identifier, always `"mysql"`
 # + host - The hostname of the database server
 # + user - The username for the database connection
 # + password - The password for the database connection
 # + port - The port number of the database server
 # + database - The name of the database to connect to
-public type MysqlConfig record {
+public type MysqlConfig record {|
+  Mysql dbType = "mysql";
   string host = "localhost";
   string? user = ();
   string? password = ();
   int port = 3306;
   string? database = ();
-};
+|};
 
-# Represents the configuration required to connect to a database related to task coordination.
+# Represents the configuration required to connect to a PostgreSQL database related to task coordination.
 #
+# + dbType - The database type identifier, always `"postgresql"`
 # + host - The hostname of the database server
 # + user - The username for the database connection
 # + password - The password for the database connection
 # + port - The port number of the database server
 # + database - The name of the database to connect to
-public type PostgresqlConfig record {
+public type PostgresqlConfig record {|
+  Postgresql dbType = "postgresql";
   string host = "localhost";
   string? user = ();
   string? password = ();
   int port = 5432;
   string? database = ();
-};
+|};
 
 # Represents the configuration required for task coordination.
 #
@@ -63,7 +73,9 @@ public type PostgresqlConfig record {
 #             coordinating the task. It is recommended to use a unique identifier for each group of tasks.
 # + heartbeatFrequency - The interval (in seconds) for the node to update its heartbeat. Default is one second.
 public type WarmBackupConfig record {
-    DatabaseConfig databaseConfig = <MysqlConfig>{};
+    DatabaseConfig databaseConfig = {
+        dbType: "mysql"
+    };
     int livenessCheckInterval = 30;
     string taskId;
     string groupId;

--- a/ballerina/tests/listener_retry_test.bal
+++ b/ballerina/tests/listener_retry_test.bal
@@ -103,7 +103,6 @@ listener Listener retryExponentialRecurringListener = new (trigger = {
     }
 });
 
-
 time:Civil startTime = time:utcToCivil(time:utcAddSeconds(time:utcNow(), 120));
 time:Civil endTime = time:utcToCivil(time:utcAddSeconds(time:utcNow(), 125));
 
@@ -128,7 +127,8 @@ listener Listener invalidConfigListener = new (
         maxCount: 1
     },
     warmBackupConfig = {
-        databaseConfig: <MysqlConfig>{
+        databaseConfig: {
+            dbType: "mysql",
             host: "localhost",
             port: 1,
             user: "test-user",

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- [Introduce `Mysql` and `Postgresql` singleton type aliases and a `dbType` discriminator field in `MysqlConfig` and `PostgresqlConfig` to resolve ambiguous type issues in the `DatabaseConfig` union type](https://github.com/ballerina-platform/ballerina-library/issues/8694)
+
 - [Add retry support for listeners](https://github.com/wso2-enterprise/internal-support-ballerina/issues/1043)
 
 ## [2.10.0]

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -206,7 +206,9 @@ The warm backup configuration enables high availability for distributed task exe
 #             coordinating the task. It is recommended to use a unique identifier for each group of tasks.
 # + heartbeatFrequency - The interval (in seconds) for the node to update its heartbeat. Default is one second.
 public type WarmBackupConfig record {
-  DatabaseConfig databaseConfig = <MysqlConfig>{};
+  DatabaseConfig databaseConfig = {
+      dbType: "mysql"
+  };
   int livenessCheckInterval = 30;
   string taskId;
   string groupId;
@@ -215,6 +217,12 @@ public type WarmBackupConfig record {
 
 # Represents the configuration required to connect to a database related to task coordination.
 public type DatabaseConfig MysqlConfig|PostgresqlConfig;
+
+# Identifies a MySQL database type.
+public type Mysql "mysql";
+
+# Identifies a PostgreSQL database type.
+public type Postgresql "postgresql";
 ```
 
 #### 7.1.3. Retry Configuration
@@ -336,42 +344,48 @@ The task coordination system can be configured using the `WarmBackupConfig` reco
 
 The `databaseConfig` can be either MySQL or PostgreSQL. This is defined using a union type as `DatabaseConfig`. Users can choose either `task:MysqlConfig` or `task:PostgresqlConfig` based on their preferred database.
 
+The `dbType` field acts as a discriminator that makes the two record types structurally distinct, allowing the compiler to resolve the union type unambiguously. Users can omit the explicit type cast and use `{dbType: "mysql", ...}` or `{dbType: "postgresql", ...}` directly.
+
 **For PostgreSQL:**
 
 ```ballerina
-# Represents the configuration required to connect to a database related to task coordination.
+# Represents the configuration required to connect to a PostgreSQL database related to task coordination.
 #
+# + dbType - The database type identifier, always `"postgresql"`
 # + host - The hostname of the database server
 # + user - The username for the database connection
 # + password - The password for the database connection
 # + port - The port number of the database server
 # + database - The name of the database to connect to
-public type PostgresqlConfig record {
+public type PostgresqlConfig record {|
+  Postgresql dbType = "postgresql";
   string host = "localhost";
   string? user = ();
   string? password = ();
   int port = 5432;
   string? database = ();
-};
+|};
 ```
 
 **For MySQL:**
 
 ```ballerina
-# Represents the configuration required to connect to a database related to task coordination.
+# Represents the configuration required to connect to a MySQL database related to task coordination.
 #
+# + dbType - The database type identifier, always `"mysql"`
 # + host - The hostname of the database server
 # + user - The username for the database connection
 # + password - The password for the database connection
 # + port - The port number of the database server
 # + database - The name of the database to connect to
-public type MysqlConfig record {
+public type MysqlConfig record {|
+  Mysql dbType = "mysql";
   string host = "localhost";
   string? user = ();
   string? password = ();
   int port = 3306;
   string? database = ();
-};
+|};
 ```
 
 ## 8.2. Task Coordination Example

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=2.11.2-SNAPSHOT
+version=2.12.0-SNAPSHOT
 
 ballerinaLangVersion=2201.12.0
 axiomVersion=1.2.22


### PR DESCRIPTION
## Summary

- Add singleton type aliases `Mysql "mysql"` and `Postgresql "postgresql"`
- Add `dbType` discriminator field to `MysqlConfig` and `PostgresqlConfig`, making both **closed records** (`record {|...|}`)
- Resolves the compiler ambiguous type error in `DatabaseConfig = MysqlConfig|PostgresqlConfig`
- `WarmBackupConfig` default updated to `{dbType: "mysql"}` — no explicit type cast needed
- No Java changes required; the native side already reads `dbType` to select the JDBC driver

## Usage

Before (required explicit cast):
```ballerina
DatabaseConfig cfg = <MysqlConfig>{host: "db.example.com"};
```

After (discriminator resolves type unambiguously):
```ballerina
DatabaseConfig cfg = {dbType: "mysql", host: "db.example.com"};
```

## Backward Compatibility

Non-breaking (minor version bump). Explicit casts like `<MysqlConfig>{...}` continue to work.

Closes https://github.com/ballerina-platform/ballerina-library/issues/8694

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request resolves a compiler ambiguity in the DatabaseConfig union by introducing an explicit dbType discriminator for database configurations. MysqlConfig and PostgresqlConfig are now closed, discriminated records, making them structurally distinct and removing the need for explicit type casts during initialization.

### Key changes

- Added singleton discriminator types: `Mysql "mysql"` and `Postgresql "postgresql"`.
- Converted `MysqlConfig` and `PostgresqlConfig` to closed records with a `dbType` field:
  - `MysqlConfig` includes `Mysql dbType = "mysql"` (default port 3306).
  - `PostgresqlConfig` includes `Postgresql dbType = "postgresql"` (default port 5432).
- Updated `WarmBackupConfig` default to use `{ dbType: "mysql" }` so callers need not use explicit casts.
- Updated tests, documentation (spec and changelog), and examples to reflect the new discriminator-based configuration.
- Bumped package version and dependency entries to align with the changes.

### Impact

- Eliminates the compiler ambiguity for `DatabaseConfig = MysqlConfig | PostgresqlConfig`, allowing direct initialization like:
  - `DatabaseConfig cfg = { dbType: "mysql", host: "db.example.com" }`
- Backward compatible: explicit casts (e.g., `<MysqlConfig>{...}`) still work and native code is unaffected since it already reads `dbType` to select the JDBC driver.
- Improves API clarity and usability by enabling unambiguous, discriminator-based configuration initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->