### PR TITLE
Revert "Introduce dbType discriminator field to resolve DatabaseConfig ambiguous type"

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "task"
-version = "2.12.0"
+version = "2.11.1"
 authors = ["Ballerina"]
 keywords = ["task", "job", "schedule"]
 repository = "https://github.com/ballerina-platform/module-ballerina-task"
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "task-native"
-version = "2.12.0"
-path = "../native/build/libs/task-native-2.12.0-SNAPSHOT.jar"
+version = "2.11.1"
+path = "../native/build/libs/task-native-2.11.1.jar"
 
 [[platform.java21.dependency]]
 groupId="org.quartz-scheduler"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.3"
+version = "2.9.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -82,7 +82,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.12.0"
+version = "2.11.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.runtime"},

--- a/ballerina/commons.bal
+++ b/ballerina/commons.bal
@@ -24,45 +24,35 @@ public type Service distinct service object {
 # Represents the configuration required to connect to a database related to task coordination.
 public type DatabaseConfig MysqlConfig|PostgresqlConfig;
 
-# Identifies a MySQL database type.
-public type Mysql "mysql";
-
-# Identifies a PostgreSQL database type.
-public type Postgresql "postgresql";
-
-# Represents the configuration required to connect to a MySQL database related to task coordination.
+# Represents the configuration required to connect to a database related to task coordination.
 #
-# + dbType - The database type identifier, always `"mysql"`
 # + host - The hostname of the database server
 # + user - The username for the database connection
 # + password - The password for the database connection
 # + port - The port number of the database server
 # + database - The name of the database to connect to
-public type MysqlConfig record {|
-  Mysql dbType = "mysql";
+public type MysqlConfig record {
   string host = "localhost";
   string? user = ();
   string? password = ();
   int port = 3306;
   string? database = ();
-|};
+};
 
-# Represents the configuration required to connect to a PostgreSQL database related to task coordination.
+# Represents the configuration required to connect to a database related to task coordination.
 #
-# + dbType - The database type identifier, always `"postgresql"`
 # + host - The hostname of the database server
 # + user - The username for the database connection
 # + password - The password for the database connection
 # + port - The port number of the database server
 # + database - The name of the database to connect to
-public type PostgresqlConfig record {|
-  Postgresql dbType = "postgresql";
+public type PostgresqlConfig record {
   string host = "localhost";
   string? user = ();
   string? password = ();
   int port = 5432;
   string? database = ();
-|};
+};
 
 # Represents the configuration required for task coordination.
 #
@@ -73,9 +63,7 @@ public type PostgresqlConfig record {|
 #             coordinating the task. It is recommended to use a unique identifier for each group of tasks.
 # + heartbeatFrequency - The interval (in seconds) for the node to update its heartbeat. Default is one second.
 public type WarmBackupConfig record {
-    DatabaseConfig databaseConfig = {
-        dbType: "mysql"
-    };
+    DatabaseConfig databaseConfig = <MysqlConfig>{};
     int livenessCheckInterval = 30;
     string taskId;
     string groupId;

--- a/ballerina/tests/listener_retry_test.bal
+++ b/ballerina/tests/listener_retry_test.bal
@@ -103,6 +103,7 @@ listener Listener retryExponentialRecurringListener = new (trigger = {
     }
 });
 
+
 time:Civil startTime = time:utcToCivil(time:utcAddSeconds(time:utcNow(), 120));
 time:Civil endTime = time:utcToCivil(time:utcAddSeconds(time:utcNow(), 125));
 
@@ -127,8 +128,7 @@ listener Listener invalidConfigListener = new (
         maxCount: 1
     },
     warmBackupConfig = {
-        databaseConfig: {
-            dbType: "mysql",
+        databaseConfig: <MysqlConfig>{
             host: "localhost",
             port: 1,
             user: "test-user",

--- a/changelog.md
+++ b/changelog.md
@@ -6,9 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- [Introduce `Mysql` and `Postgresql` singleton type aliases and a `dbType` discriminator field in `MysqlConfig` and `PostgresqlConfig` to resolve ambiguous type issues in the `DatabaseConfig` union type](https://github.com/ballerina-platform/ballerina-library/issues/8694)
-
 - [Add retry support for listeners](https://github.com/wso2-enterprise/internal-support-ballerina/issues/1043)
 
 ## [2.10.0]

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -206,9 +206,7 @@ The warm backup configuration enables high availability for distributed task exe
 #             coordinating the task. It is recommended to use a unique identifier for each group of tasks.
 # + heartbeatFrequency - The interval (in seconds) for the node to update its heartbeat. Default is one second.
 public type WarmBackupConfig record {
-  DatabaseConfig databaseConfig = {
-      dbType: "mysql"
-  };
+  DatabaseConfig databaseConfig = <MysqlConfig>{};
   int livenessCheckInterval = 30;
   string taskId;
   string groupId;
@@ -217,12 +215,6 @@ public type WarmBackupConfig record {
 
 # Represents the configuration required to connect to a database related to task coordination.
 public type DatabaseConfig MysqlConfig|PostgresqlConfig;
-
-# Identifies a MySQL database type.
-public type Mysql "mysql";
-
-# Identifies a PostgreSQL database type.
-public type Postgresql "postgresql";
 ```
 
 #### 7.1.3. Retry Configuration
@@ -344,48 +336,42 @@ The task coordination system can be configured using the `WarmBackupConfig` reco
 
 The `databaseConfig` can be either MySQL or PostgreSQL. This is defined using a union type as `DatabaseConfig`. Users can choose either `task:MysqlConfig` or `task:PostgresqlConfig` based on their preferred database.
 
-The `dbType` field acts as a discriminator that makes the two record types structurally distinct, allowing the compiler to resolve the union type unambiguously. Users can omit the explicit type cast and use `{dbType: "mysql", ...}` or `{dbType: "postgresql", ...}` directly.
-
 **For PostgreSQL:**
 
 ```ballerina
-# Represents the configuration required to connect to a PostgreSQL database related to task coordination.
+# Represents the configuration required to connect to a database related to task coordination.
 #
-# + dbType - The database type identifier, always `"postgresql"`
 # + host - The hostname of the database server
 # + user - The username for the database connection
 # + password - The password for the database connection
 # + port - The port number of the database server
 # + database - The name of the database to connect to
-public type PostgresqlConfig record {|
-  Postgresql dbType = "postgresql";
+public type PostgresqlConfig record {
   string host = "localhost";
   string? user = ();
   string? password = ();
   int port = 5432;
   string? database = ();
-|};
+};
 ```
 
 **For MySQL:**
 
 ```ballerina
-# Represents the configuration required to connect to a MySQL database related to task coordination.
+# Represents the configuration required to connect to a database related to task coordination.
 #
-# + dbType - The database type identifier, always `"mysql"`
 # + host - The hostname of the database server
 # + user - The username for the database connection
 # + password - The password for the database connection
 # + port - The port number of the database server
 # + database - The name of the database to connect to
-public type MysqlConfig record {|
-  Mysql dbType = "mysql";
+public type MysqlConfig record {
   string host = "localhost";
   string? user = ();
   string? password = ();
   int port = 3306;
   string? database = ();
-|};
+};
 ```
 
 ## 8.2. Task Coordination Example

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=2.12.0-SNAPSHOT
+version=2.11.2-SNAPSHOT
 
 ballerinaLangVersion=2201.12.0
 axiomVersion=1.2.22


### PR DESCRIPTION
Reverts ballerina-platform/module-ballerina-task#546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request reverts the changes introduced in PR #546, which had introduced a `dbType` discriminator field for DatabaseConfig resolution. The revert simplifies the database configuration approach by removing the discriminator-based type system and replacing it with explicit, typed configuration records.

## Key Changes

**API modifications:**
- Removed the exported discriminator types `Mysql` and `Postgresql`
- Introduced new explicit record types `MysqlConfig` and `PostgresqlConfig` with dedicated fields for host, user, password, port, and database
- Updated `WarmBackupConfig` to use typed configuration (`<MysqlConfig>{}`) instead of inline records with discriminator fields
- Added a new `heartbeatFrequency` field to `WarmBackupConfig`

**Version and dependency updates:**
- Downgraded package version from 2.12.0 to 2.11.1
- Updated corresponding dependency versions for the task-native library and gradle properties
- Updated crypto and task package dependencies to earlier compatible versions

**Documentation and test updates:**
- Updated the specification documentation to reflect the simplified configuration structure
- Modified test files to use the new typed configuration approach
- Removed changelog entries related to the discriminator field feature

The revert simplifies the configuration structure while maintaining type safety through explicit record definitions rather than discriminator fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->