### PR TITLE
Migrate to Gradle 9.5.1 and Java 25

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,5 +10,5 @@ jobs:
   call_workflow:
     name: Run PR Build Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@java-25-migration
     secrets: inherit

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["task", "job", "schedule"]
 repository = "https://github.com/ballerina-platform/module-ballerina-task"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.14.0-20260527-050400-74f7e6bf"
+distribution = "2201.14.0"
 
 [platform.java25]
 graalvmCompatible = true

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,25 +1,25 @@
 [package]
 org = "ballerina"
 name = "task"
-version = "2.11.1"
+version = "2.11.2"
 authors = ["Ballerina"]
 keywords = ["task", "job", "schedule"]
 repository = "https://github.com/ballerina-platform/module-ballerina-task"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.12.0"
+distribution = "2201.14.0-20260527-050400-74f7e6bf"
 
-[platform.java21]
+[platform.java25]
 graalvmCompatible = true
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "task-native"
-version = "2.11.1"
-path = "../native/build/libs/task-native-2.11.1.jar"
+version = "2.11.2"
+path = "../native/build/libs/task-native-2.11.2-SNAPSHOT.jar"
 
-[[platform.java21.dependency]]
-groupId="org.quartz-scheduler"
-artifactId="quartz"
-version="2.3.2"
+[[platform.java25.dependency]]
+groupId = "org.quartz-scheduler"
+artifactId = "quartz"
+version = "2.3.2"
 path = "./lib/quartz-2.3.2.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.0"
+distribution-version = "2201.14.0-20260527-050400-74f7e6bf"
 
 [[package]]
 org = "ballerina"
@@ -82,7 +82,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.1"
+version = "2.11.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.runtime"},

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -16,6 +16,51 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
+
+abstract class PatchBallerinaScriptsTask extends DefaultTask {
+    @Inject abstract JavaToolchainService getJavaToolchainService()
+
+    @TaskAction
+    void patch() {
+        def launcher = javaToolchainService.launcherFor { spec ->
+            spec.languageVersion.set(JavaLanguageVersion.of(25))
+        }.get()
+        def java25Home = launcher.executablePath.asFile.parentFile.parentFile.absolutePath
+
+        def binDirs = [
+            project.layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile,
+            new File("${project.rootDir}/target/ballerina-runtime/bin")
+        ]
+        binDirs.each { binDir ->
+            if (binDir.exists()) {
+                binDir.eachFile { file ->
+                    file.setExecutable(true)
+                    if (!file.name.endsWith('.bat') && !file.name.endsWith('.cmd')) {
+                        def original = file.text
+                        def lines = original.split('\n').toList()
+                        // Remove flag removed in Java 25
+                        lines = lines.findAll { !it.contains('--sun-misc-unsafe-memory-access=allow') }
+                        // Inject JAVA_HOME so the bal script picks up Java 25
+                        def shebangIdx = lines.findIndexOf { it.startsWith('#!') }
+                        if (shebangIdx >= 0) {
+                            lines.add(shebangIdx + 1, "export JAVA_HOME='${java25Home}'")
+                        }
+                        def patched = lines.join('\n') + '\n'
+                        if (patched != original) { file.text = patched }
+                    }
+                }
+            }
+        }
+    }
+}
 
 plugins {
     id 'io.ballerina.plugin'
@@ -69,8 +114,9 @@ task updateTomlFiles {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit Ballerina.toml Dependencies.toml -m \"[Automated] Update the native jar versions\""
@@ -100,11 +146,18 @@ publishing {
     }
 }
 
+task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
+    dependsOn 'unpackJballerinaTools'
+}
+
 updateTomlFiles.dependsOn copyStdlibs
 
 build.dependsOn "generatePomFileForMavenPublication"
 build.dependsOn ":${packageName}-native:build"
+build.dependsOn patchBallerinaScripts
 test.dependsOn ":${packageName}-native:build"
+test.dependsOn patchBallerinaScripts
+copyStdlibs.dependsOn patchBallerinaScripts
 
 publishToMavenLocal.dependsOn build
 publish.dependsOn build

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -27,6 +27,8 @@ abstract class BallerinaExecHelper {
 
 abstract class PatchBallerinaScriptsTask extends DefaultTask {
     @Inject abstract JavaToolchainService getJavaToolchainService()
+    @Input abstract Property<String> getJballerinaToolsBinPath()
+    @Input abstract Property<String> getBallerinaRuntimeBinPath()
 
     @TaskAction
     void patch() {
@@ -35,22 +37,16 @@ abstract class PatchBallerinaScriptsTask extends DefaultTask {
         }.get()
         def java25Home = launcher.executablePath.asFile.parentFile.parentFile.absolutePath
 
-        def binDirs = [
-            project.layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile,
-            new File("${project.rootDir}/target/ballerina-runtime/bin")
-        ]
-        binDirs.each { binDir ->
+        [new File(jballerinaToolsBinPath.get()), new File(ballerinaRuntimeBinPath.get())].each { binDir ->
             if (binDir.exists()) {
                 binDir.eachFile { file ->
                     file.setExecutable(true)
                     if (!file.name.endsWith('.bat') && !file.name.endsWith('.cmd')) {
                         def original = file.text
                         def lines = original.split('\n').toList()
-                        // Remove flag removed in Java 25
-                        lines = lines.findAll { !it.contains('--sun-misc-unsafe-memory-access=allow') }
-                        // Inject JAVA_HOME so the bal script picks up Java 25
+                        lines = lines.collect { it.replace('--sun-misc-unsafe-memory-access=allow', '').trim() }.findAll { !it.isEmpty() }
                         def shebangIdx = lines.findIndexOf { it.startsWith('#!') }
-                        if (shebangIdx >= 0) {
+                        if (shebangIdx >= 0 && !lines.any { it.startsWith('export JAVA_HOME=') }) {
                             lines.add(shebangIdx + 1, "export JAVA_HOME='${java25Home}'")
                         }
                         def patched = lines.join('\n') + '\n'
@@ -148,6 +144,9 @@ publishing {
 
 task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
     dependsOn 'unpackJballerinaTools'
+    outputs.upToDateWhen { !tasks.named('unpackJballerinaTools').get().didWork }
+    jballerinaToolsBinPath = layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile.absolutePath
+    ballerinaRuntimeBinPath = "${rootProject.projectDir.absolutePath}/target/ballerina-runtime/bin"
 }
 
 updateTomlFiles.dependsOn copyStdlibs

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -28,7 +28,7 @@ task downloadCheckstyleRuleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {
@@ -39,10 +39,10 @@ clean {
     enabled = false
 }
 
-artifacts.add('default', file("$project.buildDir/checkstyle.xml")) {
+artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
 
-artifacts.add('default', file("$project.buildDir/suppressions.xml")) {
+artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["task", "job", "schedule"]
 repository = "https://github.com/ballerina-platform/module-ballerina-task"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.14.0-20260527-050400-74f7e6bf"
+distribution = "2201.14.0"
 
 [platform.java25]
 graalvmCompatible = true

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,19 +7,19 @@ keywords = ["task", "job", "schedule"]
 repository = "https://github.com/ballerina-platform/module-ballerina-task"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.12.0"
+distribution = "2201.14.0-20260527-050400-74f7e6bf"
 
-[platform.java21]
+[platform.java25]
 graalvmCompatible = true
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "task-native"
 version = "@toml.version@"
 path = "../native/build/libs/task-native-@project.version@.jar"
 
-[[platform.java21.dependency]]
-groupId="org.quartz-scheduler"
-artifactId="quartz"
-version="@quartz.version@"
+[[platform.java25.dependency]]
+groupId = "org.quartz-scheduler"
+artifactId = "quartz"
+version = "@quartz.version@"
 path = "./lib/quartz-@quartz.version@.jar"

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ allprojects {
     apply plugin: 'jacoco'
     apply plugin: 'maven-publish'
 
+    jacoco {
+        toolVersion = "${jacocoVersion}"
+    }
+
     repositories {
         mavenLocal()
         maven {
@@ -63,6 +67,14 @@ allprojects {
 }
 
 subprojects {
+
+    plugins.withId('java') {
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(25)
+            }
+        }
+    }
 
     configurations {
         ballerinaStdLibs
@@ -99,6 +111,6 @@ release {
     }
 }
 
-task build {
+tasks.named('build') {
     dependsOn('task-ballerina:build')
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,15 +2,16 @@ org.gradle.caching=true
 group=io.ballerina.stdlib
 version=2.11.2-SNAPSHOT
 
-ballerinaLangVersion=2201.12.0
+ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
 axiomVersion=1.2.22
 checkstylePluginVersion=10.12.0
-ballerinaGradlePluginVersion=2.3.0
-spotbugsPluginVersion=6.0.18
+ballerinaGradlePluginVersion=4.0.0
+spotbugsPluginVersion=6.5.1
 shadowJarPluginVersion=7.1.2
 downloadPluginVersion=5.4.0
-releasePluginVersion=2.8.0
+releasePluginVersion=3.1.0
 
+jacocoVersion=0.8.13
 quartzVersion=2.3.2
 
 #stdlib dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ shadowJarPluginVersion=7.1.2
 downloadPluginVersion=5.4.0
 releasePluginVersion=3.1.0
 
-jacocoVersion=0.8.13
+jacocoVersion=0.8.14
 quartzVersion=2.3.2
 
 #stdlib dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.caching=true
 group=io.ballerina.stdlib
 version=2.11.3-SNAPSHOT
 
-ballerinaLangVersion=2201.13.5-20260717-102000-26087aa2
+ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
 axiomVersion=1.2.22
 checkstylePluginVersion=10.12.0
 ballerinaGradlePluginVersion=4.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.caching=true
 group=io.ballerina.stdlib
 version=2.11.3-SNAPSHOT
 
-ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
+ballerinaLangVersion=2201.13.5-20260717-102000-26087aa2
 axiomVersion=1.2.22
 checkstylePluginVersion=10.12.0
 ballerinaGradlePluginVersion=4.0.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -5,3 +5,4 @@ networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -52,10 +52,10 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs").get().asFile
     reports {
-        html.enabled true
-        text.enabled = true
+        html.required = true
+        text.required = true
     }
     def excludeFile = file("${rootDir}/spotbugs-exclude.xml")
     if(excludeFile.exists()) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,6 @@ pluginManagement {
     }
 
     repositories {
-        mavenLocal()
         gradlePluginPortal()
         maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/*'

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,6 +17,7 @@ pluginManagement {
     }
 
     repositories {
+        mavenLocal()
         gradlePluginPortal()
         maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/*'
@@ -29,7 +30,7 @@ pluginManagement {
 }
 
 plugins {
-    id "com.gradle.enterprise" version "3.13.2"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'task'
@@ -41,9 +42,9 @@ project(':checkstyle').projectDir = file("build-config${File.separator}checkstyl
 project(':task-native').projectDir = file('native')
 project(':task-ballerina').projectDir = file('ballerina')
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/terms-of-service'
+        termsOfUseAgree = 'yes'
     }
 }

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -45,4 +45,14 @@
         <Class name="io.ballerina.stdlib.task.utils.TaskCallBack"/>
         <Bug pattern="EI_EXPOSE_REP2"/>
     </Match>
+    <!-- Pre-existing issues surfaced by SpotBugs 4.9.x (bundled in plugin >= 6.2.0) -->
+    <Match>
+        <BugCode name="THROWS"/>
+    </Match>
+    <Match>
+        <BugCode name="AT"/>
+    </Match>
+    <Match>
+        <BugCode name="USELESS_STRING"/>
+    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
## Summary

- **Gradle 9.5.1**: Upgrade wrapper; replace removed `buildDir` API with `layout.buildDirectory`; replace `Project.exec()` with `ExecOperations` injection; migrate from `com.gradle.enterprise` to `com.gradle.develocity`; upgrade `net.researchgate.release` to 3.1.0
- **Java 25**: Add Java 25 toolchain to all subprojects; upgrade Ballerina Gradle plugin to 4.0.0 and `ballerinaLangVersion` to `2201.14.0-20260527-050400-74f7e6bf`; update all `[platform.java21]` TOML sections to `[platform.java25]`; add `patchBallerinaScripts` task to remove the `--sun-misc-unsafe-memory-access=allow` JVM flag (removed in Java 25) from the extracted `bal` binary after unpack; wire `test.dependsOn patchBallerinaScripts` to ensure patching during split CI builds
- **SpotBugs 6.5.1**: Upgrade for Java 25 class file support (requires SpotBugs 4.9.x / ASM 9.7+); add exclusions for `THROWS`, `AT`, and `USELESS_STRING` detectors introduced in SpotBugs 4.9.x
- **JaCoCo 0.8.13**: Upgrade for Java 25 class file instrumentation support
- **CI workflow**: Update to `pull-request-build-template.yml@java-25-migration` for JDK 25 runner support

## Test plan
- [ ] `./gradlew build` passes green locally (full build including tests)
- [ ] `.bala` artifact is created as `*-java25-*.bala`
- [ ] SpotBugs passes on native module and compiler-plugin-tests
- [ ] CI passes on both Ubuntu and Windows